### PR TITLE
Duplicate last Array entry if it was Dictionary

### DIFF
--- a/addons/dictionary_inspector/elements/packed_array_property_editor.gd
+++ b/addons/dictionary_inspector/elements/packed_array_property_editor.gd
@@ -63,7 +63,8 @@ func _on_add_button_pressed():
 	var type = get_array_type(stored_collection)
 	var new_value = get_default_for_type(type)
 	if stored_collection.size() > 0 && (
-		last_type_v == TYPE_OBJECT || stored_collection[-1] is Object
+		(last_type_v == TYPE_OBJECT || stored_collection[-1] is Object) ||
+		(last_type_v == TYPE_DICTIONARY || stored_collection[-1] is Dictionary)
 	):
 		new_value = stored_collection[-1].duplicate()
 


### PR DESCRIPTION
If adding a new entry to Array with Dictionarys (normal Array, not typed), duplicate the last Dictionary in the array instead of adding a blank Dictionary. Most of the time that would make more sense.